### PR TITLE
proper dependencies for mcp irq workaround

### DIFF
--- a/build_deb.sh
+++ b/build_deb.sh
@@ -88,7 +88,7 @@ Architecture: $DEBARCH
 Depends: linux-image-${KERNEL_UTS} (>= $DEB_PKGVERSION), linux-firmware-image-${KERNEL_UTS} (>= $DEB_PKGVERSION)
 Provides: linux-image-${DISTRO}
 Replaces: linux-image-4.1.15-imxv5-x0.1, linux-image-4.9.6-wb
-Conflicts: linux-image-4.1.15-imxv5-x0.1, linux-image-4.9.6-wb, wb-configs (<= 1.72)
+Conflicts: linux-image-4.1.15-imxv5-x0.1, linux-image-4.9.6-wb, wb-configs (<= 1.72), wb-hwconf-manager (<< 1.38.3)
 Installed-Size:
 Maintainer: Evgeny Boger
 Description: A metapackage for latest Linux kernel for ${FLAVOUR_DESC}


### PR DESCRIPTION
These two commits must be used at once:

94803e72aae31bc2358714fb28dfaf1b2cf244f5 gpio: mcp23s08: use edge-triggered interrupts
5c3a9ef74e446565411893917743ea6649531adb do not specify irq type for mcp23-based modules